### PR TITLE
Dependencies: migrate from python-Levenshtein to pylev

### DIFF
--- a/fast_autocomplete/dwg.py
+++ b/fast_autocomplete/dwg.py
@@ -8,7 +8,7 @@ from threading import Lock
 from fast_autocomplete.lfucache import LFUCache
 from fast_autocomplete.misc import _extend_and_repeat
 from fast_autocomplete.normalize import normalize_node_name
-from pylev import levenshtein
+from Levenshtein import distance as levenshtein_distance
 
 DELIMITER = '__'
 ORIGINAL_KEY = 'original_key'
@@ -281,7 +281,7 @@ class AutoComplete:
             for _word in self.words:
                 if abs(len(_word) - len(new_word)) > max_cost:
                     continue
-                dist = levenshtein(new_word, _word)
+                dist = levenshtein_distance(new_word, _word)
                 if dist < max_cost:
                     fuzzy_matches_len += 1
                     _value = self.words[_word].get(ORIGINAL_KEY, _word)

--- a/fast_autocomplete/dwg.py
+++ b/fast_autocomplete/dwg.py
@@ -18,6 +18,16 @@ except ImportError:
     except ImportError:
         pass
 
+if 'levenshtein_distance' not in locals():
+    raise RuntimeError("""
+        Unable to import a levenshtein distance calculation module.
+        Please add python-Levenshtein or pylev to your Python dependencies.
+
+        Installing this package as fast-autocomplete[levenshtein] or
+        fast-autocomplete[pylev] (to select an implementation via 'extras')
+        should do this for you.
+    """)
+
 DELIMITER = '__'
 ORIGINAL_KEY = 'original_key'
 INF = float('inf')

--- a/fast_autocomplete/dwg.py
+++ b/fast_autocomplete/dwg.py
@@ -16,17 +16,14 @@ except ImportError:
     try:
         from pylev import levenshtein as levenshtein_distance
     except ImportError:
-        pass
+        raise RuntimeError("""
+            Unable to import a levenshtein distance calculation module.
+            Please add python-Levenshtein or pylev to your Python dependencies.
 
-if 'levenshtein_distance' not in locals():
-    raise RuntimeError("""
-        Unable to import a levenshtein distance calculation module.
-        Please add python-Levenshtein or pylev to your Python dependencies.
-
-        Installing this package as fast-autocomplete[levenshtein] or
-        fast-autocomplete[pylev] (to select an implementation via 'extras')
-        should do this for you.
-    """)
+            Installing this package as fast-autocomplete[levenshtein] or
+            fast-autocomplete[pylev] (to select an implementation via 'extras')
+            should do this for you.
+        """)
 
 DELIMITER = '__'
 ORIGINAL_KEY = 'original_key'

--- a/fast_autocomplete/dwg.py
+++ b/fast_autocomplete/dwg.py
@@ -8,7 +8,7 @@ from threading import Lock
 from fast_autocomplete.lfucache import LFUCache
 from fast_autocomplete.misc import _extend_and_repeat
 from fast_autocomplete.normalize import normalize_node_name
-from Levenshtein import distance as levenshtein_distance
+from pylev import levenshtein
 
 DELIMITER = '__'
 ORIGINAL_KEY = 'original_key'
@@ -281,7 +281,7 @@ class AutoComplete:
             for _word in self.words:
                 if abs(len(_word) - len(new_word)) > max_cost:
                     continue
-                dist = levenshtein_distance(new_word, _word)
+                dist = levenshtein(new_word, _word)
                 if dist < max_cost:
                     fuzzy_matches_len += 1
                     _value = self.words[_word].get(ORIGINAL_KEY, _word)

--- a/fast_autocomplete/dwg.py
+++ b/fast_autocomplete/dwg.py
@@ -8,7 +8,15 @@ from threading import Lock
 from fast_autocomplete.lfucache import LFUCache
 from fast_autocomplete.misc import _extend_and_repeat
 from fast_autocomplete.normalize import normalize_node_name
-from Levenshtein import distance as levenshtein_distance
+
+# Prefer the 'Levenshtein' library implementation
+try:
+    from Levenshtein import distance as levenshtein_distance
+except ImportError:
+    try:
+        from pylev import levenshtein as levenshtein_distance
+    except ImportError:
+        pass
 
 DELIMITER = '__'
 ORIGINAL_KEY = 'original_key'

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,7 @@
 bump2version==0.5.10
 click>=6.7
 deepdiff==4.0.6
-flake8==3.5.0
+flake8==3.8.3
 mmh3==2.5.1
 pygraphviz==1.3.1
 pytest==4.6.2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,3 @@
--r requirements.txt
 bump2version==0.5.10
 click>=6.7
 deepdiff==4.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-python-Levenshtein==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-pylev==1.3.0
+python-Levenshtein==0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-Levenshtein==0.12.0
+pylev==1.3.0

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,9 @@ setup(
     author_email='sepd@fair.com',
     version=version,
     install_requires=reqs,
+    extras_require={
+        'pylev': ['pylev>=1.3.0'],
+    },
     dependency_links=[],
     packages=find_packages(exclude=('tests', 'docs')),
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,6 @@ from setuptools import setup, find_packages
 version = '0.6.0'
 
 
-def get_reqs(filename):
-    with open(filename, "r") as reqs_file:
-        reqs = reqs_file.readlines()
-        reqs = list(map(lambda x: x.replace('==', '>='), reqs))
-    return reqs
-
-
-reqs = get_reqs("requirements.txt")
-
 try:
     with open('README.md') as file:
         long_description = file.read()
@@ -27,8 +18,9 @@ setup(
     url='https://github.com/wearefair/fast-autocomplete',
     author_email='sepd@fair.com',
     version=version,
-    install_requires=reqs,
+    install_requires=[],
     extras_require={
+        'levenshtein': ['python-Levenshtein>=0.12.0'],
         'pylev': ['pylev>=1.3.0'],
     },
     dependency_links=[],


### PR DESCRIPTION
This is a tentative suggestion, and doesn't include performance impact analysis.

[`pylev`](https://github.com/toastdriven/pylev) is a pure-python implementation of the Levenshtein distance calculation, and I believe it can be used as a drop-in replacement for [`python-Levenshtein`](https://github.com/miohtama/python-Levenshtein).

The main purpose of the switch to `pylev` for the use case I'm looking at is that it removes a number of container build-time dependencies, including the need to compile C code at build-time.  Switching to `pylev` should (I believe) make `fast-autocomplete` usable in pure-Python container environments (`pygraphviz` and some other optional dependencies may still require C compilation steps).

NB: `pylev` does use a slightly more permissive license (New BSD rather than GPL) which could also factor into vendor preference.