### PR TITLE
Fixup: update cache key reference to requirements.txt (removed)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: deps1-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: deps1-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}
       - run:
           command: |
             sudo apt install graphviz
@@ -16,7 +16,7 @@ jobs:
             . venv/bin/activate
             pip install -r requirements-dev.txt
       - save_cache:
-          key: deps1-{{ checksum "requirements.txt" }}-{{ checksum "requirements-dev.txt" }}
+          key: deps1-{{ checksum "setup.py" }}-{{ checksum "requirements-dev.txt" }}
           paths:
             - "venv"
       - run:


### PR DESCRIPTION
I missed this reference to `requirements.txt` while developing #14; using `setup.py` as a dependency cache key should be relatively stable and maintains the property that the cache should be invalidated when dependencies are updated (although unfortunately it may also invalidate the cache during other unrelated changes)

May resolve #15 